### PR TITLE
chat-space　データベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :group_users
-- has_many :group,  through: :group_users
+- has_many :groups,  through: :group_users
 
 ## messagesテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -22,3 +22,53 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# chat-space  DB設計
+
+##  usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|nickname|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :group_users
+- has_many :group,  through: :group_users
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|image|text||
+|text|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|image|text||
+|text|text|null: false|
+|groupname|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+-  has_many :messages
+-  has_many :group_users
+-  has_many :users,  through:  :group_users
+
+##  group_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :group_users
-- has_many :groups,  through: :group_users
+- has_many :groupss,  through: :group_users
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |image|text||
-|text|text|null: false|
+|text|text||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
@@ -52,10 +52,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|image|text||
-|text|text|null: false|
-|groupname|text|null: false|
-|user_id|integer|null: false, foreign_key: true|
+|name|string|null: false|
 
 ### Association
 -  has_many :messages


### PR DESCRIPTION
#What
chat-spaceのデータベース設計を行う。
READM.mdにテーブル、アソシエーションを含むデータベース設計を記載した。


#Why
データ同士の関係性を明確にし、効率のよいデータ操作を可能にするため。